### PR TITLE
ci: dont upload PRs to releases.drivechain.info

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -46,12 +46,6 @@ jobs:
       - name: 'Set environment variables: version number'
         run: |
           BITCOIN_PATCHED_VERSION=$(grep -oP "(?<=^CMAKE_PROJECT_VERSION:STATIC=).+(?=)" build/CMakeCache.txt)
-          BRANCH_NAME=${GITHUB_REF#refs/heads/}
-          # Escape '/', '\' and space characters
-          ESCAPED_BRANCH_NAME=$(echo "$BRANCH_NAME" | sed 's/[\/\\ ]/\\&/g')
-          if [ "$ESCAPED_BRANCH_NAME" != "master" ]; then
-            BITCOIN_PATCHED_VERSION="${ESCAPED_BRANCH_NAME}-${BITCOIN_PATCHED_VERSION}"
-          fi
           echo "BITCOIN_PATCHED_VERSION=$BITCOIN_PATCHED_VERSION" >> "$GITHUB_ENV"
 
       - uses: actions/upload-artifact@v4
@@ -62,7 +56,6 @@ jobs:
             build/src/bitcoind
             build/src/bitcoin-cli
             build/src/qt/bitcoin-qt
-
 
   build-windows: 
     name: Build Windows binaries
@@ -107,12 +100,6 @@ jobs:
       - name: 'Set environment variables: version number'
         run: |
           BITCOIN_PATCHED_VERSION=$(grep -oP "(?<=^CMAKE_PROJECT_VERSION:STATIC=).+(?=)" build/CMakeCache.txt)
-          BRANCH_NAME=${GITHUB_REF#refs/heads/}
-          # Escape '/', '\' and space characters
-          ESCAPED_BRANCH_NAME=$(echo "$BRANCH_NAME" | sed 's/[\/\\ ]/\\&/g')
-          if [ "$ESCAPED_BRANCH_NAME" != "master" ]; then
-            BITCOIN_PATCHED_VERSION="${ESCAPED_BRANCH_NAME}-${BITCOIN_PATCHED_VERSION}"
-          fi
           echo "BITCOIN_PATCHED_VERSION=$BITCOIN_PATCHED_VERSION" >> "$GITHUB_ENV"
 
       - uses: actions/upload-artifact@v4
@@ -162,12 +149,6 @@ jobs:
       - name: 'Set environment variables: version number'
         run: |
           BITCOIN_PATCHED_VERSION=$(ggrep -oP "(?<=^CMAKE_PROJECT_VERSION:STATIC=).+(?=)" build/CMakeCache.txt)
-          BRANCH_NAME=${GITHUB_REF#refs/heads/}
-          # Escape '/', '\' and space characters
-          ESCAPED_BRANCH_NAME=$(echo "$BRANCH_NAME" | sed 's/[\/\\ ]/\\&/g')
-          if [ "$ESCAPED_BRANCH_NAME" != "master" ]; then
-            BITCOIN_PATCHED_VERSION="${ESCAPED_BRANCH_NAME}-${BITCOIN_PATCHED_VERSION}"
-          fi
           echo "BITCOIN_PATCHED_VERSION=$BITCOIN_PATCHED_VERSION" >> "$GITHUB_ENV"
 
       - uses: actions/upload-artifact@v4

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -164,22 +164,25 @@ jobs:
     name: Upload artifacts to releases.drivechain.info
     runs-on: ubuntu-latest
     needs: [build-linux, build-macos, build-windows]
-    if: github.repository_owner == 'LayerTwo-Labs'
+    if: >
+      (github.event_name == 'push' &&
+      github.repository_owner == 'LayerTwo-Labs' &&
+      github.ref == 'refs/heads/master') ||
+      github.ref == 'refs/heads/some-whitelisted-branch'
     steps:
       - name: Download artifacts
         uses: actions/download-artifact@v4
-
       - name: Zip artifacts
         run: |
-          ARTIFACT_PREFIX=''
-          BRANCH_NAME=${GITHUB_REF#refs/heads/}
-          # Escape '/', '\' and space characters
-          ESCAPED_BRANCH_NAME=$(echo "$BRANCH_NAME" | sed 's/[\/\\ ]/\\&/g')
-          if [ "$ESCAPED_BRANCH_NAME" != "master" ]; then
-            ARTIFACT_PREFIX="L1-bitcoin-patched-${ESCAPED_BRANCH_NAME}-latest"
+          if [ "${{ github.ref }}" == "refs/heads/master" ]; then
+            VERSION="latest"
           else
-            ARTIFACT_PREFIX="L1-bitcoin-patched-latest"
+            # We're on a PR, use the branch name
+            VERSION="${{ github.head_ref }}"
           fi
+
+          ARTIFACT_PREFIX="L1-bitcoin-patched-$VERSION"
+          
           mv bitcoin-patched-*-x86_64-apple-darwin "${ARTIFACT_PREFIX}-x86_64-apple-darwin"
           zip -r "${ARTIFACT_PREFIX}-x86_64-apple-darwin.zip" "${ARTIFACT_PREFIX}-x86_64-apple-darwin"
           mv bitcoin-patched-*-x86_64-w64-mingw32 "${ARTIFACT_PREFIX}-x86_64-w64-mingw32"
@@ -195,4 +198,4 @@ jobs:
           pass: ${{ secrets.RELEASES_SERVER_PW }}
           port: 22
           scp: |
-            'L1-bitcoin-patched-*latest-*.zip' => '/var/www/html/'
+            'L1-bitcoin-patched-*.zip' => '/var/www/html/'


### PR DESCRIPTION
Prior to this change, the version set was invalid, and CI failed with error messages like `The artifact name is not valid: bitcoin-patched-refs\/pull\/4\/merge-28.99.0-x86_64-unknown-linux-gnu. Contains the following character:  Backslash \`

In this PR we make sure to only upload white-listed branches (none as of yet) and master pushes to releases.drivechain.info. Also remove sed-extraction of the branch-name entirely. Use github.head_ref instead.
