### PR TITLE
ci: build from completely untouched core

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -1,0 +1,201 @@
+name: Build and Release
+
+on: 
+  pull_request: 
+  push: 
+    branches:
+      - "master"
+  workflow_dispatch:
+
+jobs: 
+  build-linux: 
+    name: Build Linux binaries
+    runs-on: ubuntu-24.04
+    steps: 
+      - name: install Linux deps
+        run: |
+          sudo apt-get install build-essential cmake libboost-dev \
+              libevent-dev pkg-config python3 qtbase5-dev qttools5-dev \
+              qttools5-dev-tools qtwayland5
+
+      - uses: actions/checkout@v4
+    
+      - name: Restore cached dependencies
+        uses: actions/cache/restore@v4
+        with:
+          path: ./depends
+          key: linux-${{ hashFiles('depends/packages/**') }}
+
+      - name: download dependencies
+        run: make -C ./depends download-linux
+
+      - name: build dependencies
+        run: make -C ./depends -j4
+
+      - name: Cache dependencies
+        uses: actions/cache/save@v4
+        with:
+          path: ./depends
+          key: linux-${{ hashFiles('depends/packages/**') }}
+
+      - name: build
+        run: |
+          cmake -B build --toolchain depends/x86_64-pc-linux-gnu/toolchain.cmake
+          cmake --build build -j 4
+
+      - name: 'Set environment variables: version number'
+        run: |
+          BITCOIN_PATCHED_VERSION=$(grep -oP "(?<=^CMAKE_PROJECT_VERSION:STATIC=).+(?=)" build/CMakeCache.txt)
+          echo "BITCOIN_PATCHED_VERSION=$BITCOIN_PATCHED_VERSION" >> "$GITHUB_ENV"
+
+      - uses: actions/upload-artifact@v4
+        with: 
+          name: bitcoin-patched-${{ env.BITCOIN_PATCHED_VERSION }}-x86_64-unknown-linux-gnu
+          if-no-files-found: error
+          path: |
+            build/src/bitcoind
+            build/src/bitcoin-cli
+            build/src/qt/bitcoin-qt
+
+  build-windows: 
+    name: Build Windows binaries
+    runs-on: ubuntu-24.04
+    steps: 
+        # g++-mingw-w64-x86-64 is the cross-compiling toolchain needed for 
+        # producing Windows binaries
+      - name: install deps
+        run: |
+          sudo apt install g++-mingw-w64-x86-64 build-essential cmake curl \
+              libboost-dev libtool libevent-dev pkg-config curl git python3 \
+              qtbase5-dev qttools5-dev qttools5-dev-tools
+
+      - name: configure the Windows toolchain
+        run: sudo update-alternatives --set x86_64-w64-mingw32-g++ /usr/bin/x86_64-w64-mingw32-g++-posix
+
+      - uses: actions/checkout@v4
+    
+      - name: Restore cached dependencies
+        uses: actions/cache/restore@v4
+        with:
+          path: ./depends
+          key: windows-${{ hashFiles('depends/packages/**') }}
+        
+      - name: download dependencies
+        run: make -C ./depends download-win
+
+      - name: build dependencies
+        run: gmake -C ./depends HOST=x86_64-w64-mingw32 -j 4
+
+      - name: Cache dependencies
+        uses: actions/cache/save@v4
+        with:
+          path: ./depends
+          key: windows-${{ hashFiles('depends/packages/**') }}
+
+      - name: build
+        run: |
+          cmake -B build --toolchain depends/x86_64-w64-mingw32/toolchain.cmake
+          cmake --build build -j 4
+
+      - name: 'Set environment variables: version number'
+        run: |
+          BITCOIN_PATCHED_VERSION=$(grep -oP "(?<=^CMAKE_PROJECT_VERSION:STATIC=).+(?=)" build/CMakeCache.txt)
+          echo "BITCOIN_PATCHED_VERSION=$BITCOIN_PATCHED_VERSION" >> "$GITHUB_ENV"
+
+      - uses: actions/upload-artifact@v4
+        with: 
+          name: bitcoin-patched-${{ env.BITCOIN_PATCHED_VERSION }}-x86_64-w64-mingw32
+          if-no-files-found: error
+          path: |
+            build/src/bitcoind.exe
+            build/src/bitcoin-cli.exe
+            build/src/qt/bitcoin-qt.exe
+
+  build-macos: 
+    name: Build macOS binaries
+    runs-on: macos-13
+    steps: 
+      - uses: actions/checkout@v3
+    
+      - name: install deps
+        run: |
+          # GNU grep is required, as BSD grep does not support perl regexes
+          brew install boost cmake grep libevent pkg-config qrencode qt@5
+
+      - name: Restore cached dependencies
+        uses: actions/cache/restore@v4
+        with:
+          path: ./depends
+          key: macos-${{ hashFiles('depends/packages/**') }}    
+      
+      - name: download dependencies
+        run: make -C ./depends download-osx
+
+      - name: build dependencies
+        run: make -C ./depends -j 4
+
+      - name: Cache dependencies
+        uses: actions/cache/save@v4
+        with:
+          path: ./depends
+          key: macos-${{ hashFiles('depends/packages/**') }}
+
+      - name: build
+        run: |
+          ls depends
+          cmake -B build -DBUILD_GUI=ON --toolchain depends/x86_64-apple-darwin*/toolchain.cmake
+          cmake --build build -j 4
+
+      - name: 'Set environment variables: version number'
+        run: |
+          BITCOIN_PATCHED_VERSION=$(ggrep -oP "(?<=^CMAKE_PROJECT_VERSION:STATIC=).+(?=)" build/CMakeCache.txt)
+          echo "BITCOIN_PATCHED_VERSION=$BITCOIN_PATCHED_VERSION" >> "$GITHUB_ENV"
+
+      - uses: actions/upload-artifact@v4
+        with: 
+          name: bitcoin-patched-${{ env.BITCOIN_PATCHED_VERSION }}-x86_64-apple-darwin
+          if-no-files-found: error
+          path: |
+            build/src/bitcoind
+            build/src/bitcoin-cli
+            build/src/qt/bitcoin-qt
+
+  upload-artifacts-to-releases-drivechain-info:
+    name: Upload artifacts to releases.drivechain.info
+    runs-on: ubuntu-latest
+    needs: [build-linux, build-macos, build-windows]
+    if: >
+      (github.event_name == 'push' &&
+      github.repository_owner == 'LayerTwo-Labs' &&
+      github.ref == 'refs/heads/master') ||
+      github.ref == 'refs/heads/some-whitelisted-branch'
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+      - name: Zip artifacts
+        run: |
+          if [ "${{ github.ref }}" == "refs/heads/master" ]; then
+            VERSION="latest"
+          else
+            # We're on a PR, use the branch name
+            VERSION="${{ github.head_ref }}"
+          fi
+
+          ARTIFACT_PREFIX="L1-bitcoin-patched-$VERSION"
+          
+          mv bitcoin-patched-*-x86_64-apple-darwin "${ARTIFACT_PREFIX}-x86_64-apple-darwin"
+          zip -r "${ARTIFACT_PREFIX}-x86_64-apple-darwin.zip" "${ARTIFACT_PREFIX}-x86_64-apple-darwin"
+          mv bitcoin-patched-*-x86_64-w64-mingw32 "${ARTIFACT_PREFIX}-x86_64-w64-mingw32"
+          zip -r "${ARTIFACT_PREFIX}-x86_64-w64-mingw32.zip" "${ARTIFACT_PREFIX}-x86_64-w64-mingw32"
+          mv bitcoin-patched-*-x86_64-unknown-linux-gnu "${ARTIFACT_PREFIX}-x86_64-unknown-linux-gnu"
+          zip -r "${ARTIFACT_PREFIX}-x86_64-unknown-linux-gnu.zip" "${ARTIFACT_PREFIX}-x86_64-unknown-linux-gnu"
+
+      - name: Upload artifacts to releases.drivechain.info
+        uses: cross-the-world/ssh-scp-ssh-pipelines@latest
+        with:
+          host: 45.33.96.47
+          user: root
+          pass: ${{ secrets.RELEASES_SERVER_PW }}
+          port: 22
+          scp: |
+            'L1-bitcoin-patched-*.zip' => '/var/www/html/'


### PR DESCRIPTION
<!--
*** Please remove the following help text before submitting: ***

Pull requests without a rationale and clear improvement may be closed
immediately.

GUI-related pull requests should be opened against
https://github.com/bitcoin-core/gui
first. See CONTRIBUTING.md
-->

<!--
Please provide clear motivation for your patch and explain how it improves
Bitcoin Core user experience or Bitcoin Core developer experience
significantly:

* Any test improvements or new tests that improve coverage are always welcome.
* All other changes should have accompanying unit tests (see `src/test/`) or
  functional tests (see `test/`). Contributors should note which tests cover
  modified code. If no tests exist for a region of modified code, new tests
  should accompany the change.
* Bug fixes are most welcome when they come with steps to reproduce or an
  explanation of the potential issue as well as reasoning for the way the bug
  was fixed.
* Features are welcome, but might be rejected due to design or scope issues.
  If a feature is based on a lot of dependencies, contributors should first
  consider building the system outside of Bitcoin Core, if possible.
* Refactoring changes are only accepted if they are required for a feature or
  bug fix or otherwise improve developer experience significantly. For example,
  most "code style" refactoring changes require a thorough explanation why they
  are useful, what downsides they have and why they *significantly* improve
  developer experience or avoid serious programming bugs. Note that code style
  is often a subjective matter. Unless they are explicitly mentioned to be
  preferred in the [developer notes](/doc/developer-notes.md), stylistic code
  changes are usually rejected.
-->

<!--
Bitcoin Core has a thorough review process and even the most trivial change
needs to pass a lot of eyes and requires non-zero or even substantial time
effort to review. There is a huge lack of active reviewers on the project, so
patches often sit for a long time.
-->
