### PR TITLE
contrib/signet/miner: fix order of log params

### DIFF
--- a/contrib/signet/miner
+++ b/contrib/signet/miner
@@ -517,8 +517,8 @@ def do_generate(args):
         # We used to log the payout address here. Due to moving to getting the coinbase
         # transaction via `getblocktemplate`, we would now need to inspect the block
         # to find the actual payout address. Don't bother!
-        logging.info("Mined %s at height %d (%s); next in %s (%s)", 
-                     bstr, block.hash, tmpl["height"], 
+        logging.info("Mined %s at height %d (%s); next in %s (%s)",
+                     bstr, tmpl["height"], block.hash,
                      seconds_to_hms(next_delta), ("mine" if next_is_mine else "backup"))
         if r != "":
             logging.warning("submitblock returned %s for height %d hash %s", r, tmpl["height"], block.hash)

--- a/l2l-signet.md
+++ b/l2l-signet.md
@@ -22,6 +22,8 @@ easy enough to get the gist if using an inferior shell like Bash or Zsh.
     $ ./build/src/bitcoin-cli -regtest -datadir=$PWD/l2l-signet \
          createwallet l2l-signet
 
+    $ set address (./build/src/bitcoin-cli -regtest -datadir=$PWD/l2l-signet getnewaddress)
+
     $ set signet_challenge (./build/src/bitcoin-cli -regtest -datadir=$PWD/l2l-signet \
                          getaddressinfo $address | jq -r .scriptPubKey)
 
@@ -43,7 +45,7 @@ easy enough to get the gist if using an inferior shell like Bash or Zsh.
     $ ./build/src/bitcoin-cli -signet -datadir=$PWD/l2l-signet \
          createwallet l2l-signet
 
-    $ ./build/src/bitcoin-cli signet -datadir=$PWD/l2l-signet \
+    $ ./build/src/bitcoin-cli -signet -datadir=$PWD/l2l-signet \
         importdescriptors "$descriptors"
 
     ```


### PR DESCRIPTION
Fixes invalid order of parameters in the mining script, which leads to an exception being thrown.

Also updates the signet creation document. 
