### PR TITLE
build-windows: put binaries directly in artifacts/ not artifacts/Release

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -141,23 +141,21 @@ jobs:
       - name: Rename artifacts before upload
         run: |
           mkdir artifacts
-          mkdir artifacts/Release
-          mv build/src/Release/bitcoind.exe artifacts/Release/
-          mv build/src/Release/bitcoin-cli.exe artifacts/Release/
-          mv build/src/Release/bitcoin-util.exe artifacts/Release/
+          mv build/src/Release/bitcoind.exe artifacts/
+          mv build/src/Release/bitcoin-cli.exe artifacts/
+          mv build/src/Release/bitcoin-util.exe artifacts/
           mkdir artifacts/qt
-          mkdir artifacts/qt/Release
-          mv build/src/qt/Release/bitcoin-qt.exe artifacts/qt/Release/
+          mv build/src/qt/Release/bitcoin-qt.exe artifacts/qt/
 
       - uses: actions/upload-artifact@v4
         with: 
           name: bitcoin-patched-${{ env.BITCOIN_PATCHED_VERSION }}-x86_64-w64-msvc
           if-no-files-found: error
           path: |
-            artifacts/Release/bitcoind.exe
-            artifacts/Release/bitcoin-cli.exe
-            artifacts/Release/bitcoin-util.exe
-            artifacts/qt/Release/bitcoin-qt.exe
+            artifacts/bitcoind.exe
+            artifacts/bitcoin-cli.exe
+            artifacts/bitcoin-util.exe
+            artifacts/qt/bitcoin-qt.exe
 
   build-macos: 
     name: Build macOS binaries

--- a/src/common/args.cpp
+++ b/src/common/args.cpp
@@ -726,7 +726,7 @@ fs::path GetDefaultDataDir()
     // Unix-like: ~/.drivechain
 #ifdef WIN32
     // Windows
-    return GetSpecialFolderPath(CSIDL_LOCAL_APPDATA) / "drivechain";
+    return GetSpecialFolderPath(CSIDL_APPDATA) / "Drivechain";
 #else
     fs::path pathRet;
     char* pszHome = getenv("HOME");
@@ -736,7 +736,7 @@ fs::path GetDefaultDataDir()
         pathRet = fs::path(pszHome);
 #ifdef MAC_OSX
     // macOS
-    return pathRet / "Library/Application Support/drivechain";
+    return pathRet / "Library/Application Support/Drivechain";
 #else
     // Unix-like
     return pathRet / ".drivechain";


### PR DESCRIPTION
this way windows doesn't have to be special cased in our other software.

`\Roaming\<chain>` for all chains!