### PR TITLE
add replay protection via magic nLockTime

### DIFF
--- a/src/consensus/tx_verify.cpp
+++ b/src/consensus/tx_verify.cpp
@@ -16,7 +16,7 @@
 
 bool IsFinalTx(const CTransaction &tx, int nBlockHeight, int64_t nBlockTime)
 {
-    if (tx.nLockTime == 0)
+    if (tx.nLockTime == 0 || tx.nLockTime == LOCKTIME_THRESHOLD - 1)
         return true;
     if ((int64_t)tx.nLockTime < ((int64_t)tx.nLockTime < LOCKTIME_THRESHOLD ? (int64_t)nBlockHeight : nBlockTime))
         return true;

--- a/src/script/interpreter.cpp
+++ b/src/script/interpreter.cpp
@@ -1722,7 +1722,7 @@ bool GenericTransactionSignatureChecker<T>::CheckLockTime(const CScriptNum& nLoc
     // unless the type of nLockTime being tested is the same as
     // the nLockTime in the transaction.
     if (!(
-        (txTo->nLockTime <  LOCKTIME_THRESHOLD && nLockTime <  LOCKTIME_THRESHOLD) ||
+        (txTo->nLockTime <  LOCKTIME_THRESHOLD - 1 && nLockTime <  LOCKTIME_THRESHOLD) ||
         (txTo->nLockTime >= LOCKTIME_THRESHOLD && nLockTime >= LOCKTIME_THRESHOLD)
     ))
         return false;

--- a/src/test/transaction_tests.cpp
+++ b/src/test/transaction_tests.cpp
@@ -1144,4 +1144,37 @@ BOOST_AUTO_TEST_CASE(max_standard_legacy_sigops)
     BOOST_CHECK(!::AreInputsStandard(CTransaction(tx_max_sigops), coins));
 }
 
+BOOST_AUTO_TEST_CASE(tx_replay_protection_locktime)
+{
+    // A transaction stamped with the magic nLockTime (LOCKTIME_THRESHOLD - 1) is
+    // always final here, so it confirms on this chain. Stock Bitcoin Core reads
+    // the same value as a block height roughly 500 million blocks away and
+    // rejects the transaction as non-final, so it can never replay onto Bitcoin.
+    CMutableTransaction tx;
+    tx.vin.resize(1);
+    // nLockTime is only enforced when at least one input is non-final.
+    tx.vin[0].nSequence = CTxIn::SEQUENCE_FINAL - 1;
+    tx.vout.resize(1);
+    tx.vout[0].nValue = 0;
+
+    // The magic locktime is final at any height and time.
+    tx.nLockTime = LOCKTIME_THRESHOLD - 1;
+    BOOST_CHECK(IsFinalTx(CTransaction(tx), /*nBlockHeight=*/1, /*nBlockTime=*/0));
+
+    // One below the magic value is an ordinary height lock, so it stays
+    // non-final until that height is reached.
+    tx.nLockTime = LOCKTIME_THRESHOLD - 2;
+    BOOST_CHECK(!IsFinalTx(CTransaction(tx), /*nBlockHeight=*/1, /*nBlockTime=*/0));
+
+    // An unlocked transaction is final, as always.
+    tx.nLockTime = 0;
+    BOOST_CHECK(IsFinalTx(CTransaction(tx), /*nBlockHeight=*/1, /*nBlockTime=*/0));
+
+    // A fully final input makes any transaction final, so the magic value
+    // changes nothing there.
+    tx.nLockTime = LOCKTIME_THRESHOLD - 2;
+    tx.vin[0].nSequence = CTxIn::SEQUENCE_FINAL;
+    BOOST_CHECK(IsFinalTx(CTransaction(tx), /*nBlockHeight=*/1, /*nBlockTime=*/0));
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/functional/feature_replay_protection.py
+++ b/test/functional/feature_replay_protection.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Test replay protection via the magic nLockTime.
+
+A transaction stamped with nLockTime == LOCKTIME_THRESHOLD - 1 is treated as
+final here, so it relays and confirms. Stock Bitcoin Core reads the same value
+as a block height roughly 500 million blocks away and rejects the transaction
+as non-final, which is what stops it replaying onto Bitcoin.
+"""
+
+from test_framework.blocktools import COINBASE_MATURITY
+from test_framework.messages import SEQUENCE_FINAL
+from test_framework.script import LOCKTIME_THRESHOLD
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import (
+    assert_equal,
+    assert_raises_rpc_error,
+)
+from test_framework.wallet import MiniWallet
+
+REPLAY_LOCKTIME = LOCKTIME_THRESHOLD - 1
+# nLockTime is only enforced when at least one input is non-final.
+NON_FINAL_SEQUENCE = SEQUENCE_FINAL - 1
+
+
+class ReplayProtectionTest(BitcoinTestFramework):
+    def set_test_params(self):
+        self.num_nodes = 1
+
+    def run_test(self):
+        node = self.nodes[0]
+        wallet = MiniWallet(node)
+        self.generate(wallet, COINBASE_MATURITY + 3)
+
+        self.log.info("A transaction with the magic nLockTime is accepted and confirms")
+        tx = wallet.create_self_transfer(locktime=REPLAY_LOCKTIME, sequence=NON_FINAL_SEQUENCE)
+        assert_equal(tx["tx"].nLockTime, REPLAY_LOCKTIME)
+        txid = node.sendrawtransaction(tx["hex"])
+        assert_equal(node.getrawmempool(), [txid])
+        blockhash = self.generate(wallet, 1)[0]
+        assert txid in node.getblock(blockhash)["tx"]
+
+        self.log.info("An ordinary far-future locktime is still rejected as non-final")
+        tx = wallet.create_self_transfer(locktime=REPLAY_LOCKTIME - 1, sequence=NON_FINAL_SEQUENCE)
+        assert_raises_rpc_error(-26, "non-final", node.sendrawtransaction, tx["hex"])
+
+        self.log.info("A fully final input is unaffected by the magic value")
+        tx = wallet.create_self_transfer(locktime=REPLAY_LOCKTIME - 1, sequence=SEQUENCE_FINAL)
+        node.sendrawtransaction(tx["hex"])
+
+
+if __name__ == '__main__':
+    ReplayProtectionTest(__file__).main()

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -285,6 +285,7 @@ BASE_SCRIPTS = [
     'rpc_getblockfrompeer.py',
     'rpc_invalidateblock.py',
     'feature_utxo_set_hash.py',
+    'feature_replay_protection.py',
     'feature_rbf.py',
     'mempool_packages.py',
     'mempool_package_onemore.py',


### PR DESCRIPTION
A transaction with nLockTime 499999999 (LOCKTIME_THRESHOLD - 1) is treated as final here, but stock Bitcoin Core reads it as a block height ~500 million blocks away (9 500 years) and rejects it as non-final. That lets a transaction confirm on this chain while being unable to replay onto Bitcoin.